### PR TITLE
Fix require in MakeMeASandwich spec.

### DIFF
--- a/spec/plugin/make_me_a_sandwich_spec.rb
+++ b/spec/plugin/make_me_a_sandwich_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../plugin/make_me_a_sandwich.rb'
+require_relative '../../plugin/make_me_a_sandwich_cinch_plugin.rb'
 
 describe TurbotPlugins::MakeMeASandwich do
   subject(:plugin){ described_class.new(double.as_null_object) }


### PR DESCRIPTION
The actual plugin file was renamed, but the spec was still referencing the old filename.
