### PR TITLE
Rename all Plugins .help to .commands.

### DIFF
--- a/plugin/chuck_norris_cinch_plugin.rb
+++ b/plugin/chuck_norris_cinch_plugin.rb
@@ -9,7 +9,7 @@ module TurbotPlugins
 
     PluginHandler.add_plugin(self)
 
-    def self.help
+    def self.commands
       PluginCommand.new("'.chuck norris', '.chuck says', '.chuck'", "Rockin' Norris Quote")
     end
 

--- a/plugin/cowsay_cinch_plugin.rb
+++ b/plugin/cowsay_cinch_plugin.rb
@@ -7,7 +7,7 @@ module TurbotPlugins
 
     PluginHandler.add_plugin(self)
 
-    def self.help
+    def self.commands
       PluginCommand.new(".cowsay", "\x02Bovine Phrase\x02 = Awesome Cowsay Graphic")
     end
 

--- a/plugin/duck_duck_go_cinch_plugin.rb
+++ b/plugin/duck_duck_go_cinch_plugin.rb
@@ -70,7 +70,7 @@ module TurbotPlugins
 
     PluginHandler.add_plugin(self)
 
-    def self.help
+    def self.commands
       PluginCommand.new(".ddg", "\x02Search Term\x02 = Perform DDG search.")
     end
 

--- a/plugin/ferengi_rules_cinch_plugin.rb
+++ b/plugin/ferengi_rules_cinch_plugin.rb
@@ -4,7 +4,7 @@ module TurbotPlugins
 
     PluginHandler.add_plugin(self)
 
-    def self.help
+    def self.commands
       PluginCommand.new(".rule of acquisition","Print a random Ferengi rule of acquisition.")
     end
 

--- a/plugin/gem_search_cinch_plugin.rb
+++ b/plugin/gem_search_cinch_plugin.rb
@@ -8,7 +8,7 @@ module TurbotPlugins
 
     PluginHandler.add_plugin(self)
 
-    def self.help
+    def self.commands
       [PluginCommand.new(".gem <search term>", "Gem Search"),
        PluginCommand.new(".gem info <search term>", "Gem Info")]
     end

--- a/plugin/github_status_cinch_plugin.rb
+++ b/plugin/github_status_cinch_plugin.rb
@@ -9,7 +9,7 @@ module TurbotPlugins
 
     PluginHandler.add_plugin(self)
 
-    def self.help
+    def self.commands
       [PluginCommand.new("'.github status'","Show latest status update for Github. (will auto-print every 5 minutes when github is having issues"),
        PluginCommand.new("'.github last message'","Show latest manual status update for Github.")]
     end

--- a/plugin/help_cinch_plugin.rb
+++ b/plugin/help_cinch_plugin.rb
@@ -4,7 +4,7 @@ module TurbotPlugins
 
     PluginHandler.add_plugin(self)
 
-    def self.help
+    def self.commands
       PluginCommand.new('.help', 'This help display.')
     end
 

--- a/plugin/make_me_a_sandwich_cinch_plugin.rb
+++ b/plugin/make_me_a_sandwich_cinch_plugin.rb
@@ -11,7 +11,7 @@ module TurbotPlugins
     WHAT  = "What? Make it yourself"
     BLANK = ""
 
-    def self.help
+    def self.commands
       PluginCommand.new("'.make me a sandwich'", "Request a tasty sandwich")
     end
 

--- a/plugin/meetup_cinch_plugin.rb
+++ b/plugin/meetup_cinch_plugin.rb
@@ -11,7 +11,7 @@ module TurbotPlugins
 
     PluginHandler.add_plugin(self)
 
-    def self.help
+    def self.commands
       PluginCommand.new(".nextmeetup", 'Get the next meetup information.')
     end
 

--- a/plugin/reddit_joke_cinch_plugin.rb
+++ b/plugin/reddit_joke_cinch_plugin.rb
@@ -9,7 +9,7 @@ module TurbotPlugins
 
     PluginHandler.add_plugin(self)
 
-    def self.help
+    def self.commands
       PluginCommand.new("'.joke me', '.joke'", "Random joke from reddit.com/r/jokes.")
     end
 

--- a/plugin/turbotinfo_cinch_plugin.rb
+++ b/plugin/turbotinfo_cinch_plugin.rb
@@ -7,7 +7,7 @@ module TurbotPlugins
 
     PluginHandler.add_plugin(self)
 
-    def self.help
+    def self.commands
       PluginCommand.new(".turbotinfo", "Information about turbot.")
     end
 

--- a/plugin_handler.rb
+++ b/plugin_handler.rb
@@ -8,7 +8,7 @@ module PluginHandler
   end
 
   def self.commands
-    plugins.inject([]) {|m,p| m += Array(p.help) }
+    plugins.inject([]) {|m,p| m += Array(p.commands) }
   end
 
   def self.matchers

--- a/spec/help_spec.rb
+++ b/spec/help_spec.rb
@@ -7,7 +7,7 @@ require_relative '../plugin/help_cinch_plugin.rb'
 class ClassThatRegistersWithPluginHandler
   PluginHandler.add_plugin(self)
 
-  def self.help
+  def self.commands
     PluginCommand.new(".nextmeetup", 'Get the next meetup information.')
   end
 end

--- a/spec/plugin/chuck_norris_spec.rb
+++ b/spec/plugin/chuck_norris_spec.rb
@@ -14,10 +14,10 @@ describe TurbotPlugins::ChuckNorris do
     end
   end
 
-  context "#help" do
+  context ".commands" do
     it "Should print the plugin's help message." do
-      plugin.class.help.matchers.should eql("'.chuck norris', '.chuck says', '.chuck'")
-      plugin.class.help.description.should eql("Rockin' Norris Quote")
+      plugin.class.commands.matchers.should eql("'.chuck norris', '.chuck says', '.chuck'")
+      plugin.class.commands.description.should eql("Rockin' Norris Quote")
     end
   end
 end

--- a/spec/plugin/cowsay_spec.rb
+++ b/spec/plugin/cowsay_spec.rb
@@ -14,10 +14,10 @@ describe TurbotPlugins::Cowsay do
     end
   end
 
-  context "#help" do
+  context ".commands" do
     it "responds to .help with information about itself." do
-      plugin.class.help.matchers.should eql(".cowsay")
-      plugin.class.help.description.should eql("\x02Bovine Phrase\x02 = Awesome Cowsay Graphic")
+      plugin.class.commands.matchers.should eql(".cowsay")
+      plugin.class.commands.description.should eql("\x02Bovine Phrase\x02 = Awesome Cowsay Graphic")
     end
   end
 end

--- a/spec/plugin/duck_duck_go_spec.rb
+++ b/spec/plugin/duck_duck_go_spec.rb
@@ -19,10 +19,10 @@ describe TurbotPlugins::DuckDuckGo do
     end
   end
 
-  context "#help" do
+  context ".commands" do
     it "Should return information about itself." do
-      plugin.class.help.matchers.should eql(".ddg")
-      plugin.class.help.description.should eql("\x02Search Term\x02 = Perform DDG search.")
+      plugin.class.commands.matchers.should eql(".ddg")
+      plugin.class.commands.description.should eql("\x02Search Term\x02 = Perform DDG search.")
     end
   end
 end

--- a/spec/plugin/ferengi_rules_spec.rb
+++ b/spec/plugin/ferengi_rules_spec.rb
@@ -26,10 +26,10 @@ describe TurbotPlugins::FerengiRules do
     end
   end
 
-  context "#help" do
+  context ".commands" do
     it "Returns information about itself." do
-      plugin.class.help.matchers.should eql(".rule of acquisition")
-      plugin.class.help.description.should eql("Print a random Ferengi rule of acquisition.")
+      plugin.class.commands.matchers.should eql(".rule of acquisition")
+      plugin.class.commands.description.should eql("Print a random Ferengi rule of acquisition.")
     end
   end
 end

--- a/spec/plugin/gem_search_spec.rb
+++ b/spec/plugin/gem_search_spec.rb
@@ -24,13 +24,13 @@ describe TurbotPlugins::GemSearch do
     end
   end
 
-  context "#help" do
+  context ".commands" do
     it "should print the plugins help message." do
-      plugin.class.help.first.matchers.should eql(".gem <search term>")
-      plugin.class.help.first.description.should eql("Gem Search")
+      plugin.class.commands.first.matchers.should eql(".gem <search term>")
+      plugin.class.commands.first.description.should eql("Gem Search")
 
-      plugin.class.help.last.matchers.should eql(".gem info <search term>")
-      plugin.class.help.last.description.should eql("Gem Info")
+      plugin.class.commands.last.matchers.should eql(".gem info <search term>")
+      plugin.class.commands.last.description.should eql("Gem Info")
     end
   end
 end

--- a/spec/plugin/github_status_spec.rb
+++ b/spec/plugin/github_status_spec.rb
@@ -24,13 +24,13 @@ describe TurbotPlugins::GithubStatus do
     end
   end
 
-  context "#help" do
+  context ".commands" do
     it "should send it's help info." do
-      plugin.class.help.first.matchers.should eql("'.github status'")
-      plugin.class.help.first.description.should eql("Show latest status update for Github. (will auto-print every 5 minutes when github is having issues")
+      plugin.class.commands.first.matchers.should eql("'.github status'")
+      plugin.class.commands.first.description.should eql("Show latest status update for Github. (will auto-print every 5 minutes when github is having issues")
 
-      plugin.class.help.last.matchers.should eql("'.github last message'")
-      plugin.class.help.last.description.should eql("Show latest manual status update for Github.")
+      plugin.class.commands.last.matchers.should eql("'.github last message'")
+      plugin.class.commands.last.description.should eql("Show latest manual status update for Github.")
     end
   end
 end

--- a/spec/plugin/make_me_a_sandwich_spec.rb
+++ b/spec/plugin/make_me_a_sandwich_spec.rb
@@ -60,10 +60,10 @@ describe TurbotPlugins::MakeMeASandwich do
     end
   end
 
-  context "#help" do
+  context ".commands" do
     it "should print the plugins help message." do
-      plugin.class.help.matchers.should eql("'.make me a sandwich'")
-      plugin.class.help.description.should eql("Request a tasty sandwich")
+      plugin.class.commands.matchers.should eql("'.make me a sandwich'")
+      plugin.class.commands.description.should eql("Request a tasty sandwich")
     end
   end
 end

--- a/spec/plugin/meetup_spec.rb
+++ b/spec/plugin/meetup_spec.rb
@@ -6,10 +6,10 @@ describe TurbotPlugins::Meetup do
   subject(:plugin){ TurbotPlugins::Meetup.new(double.as_null_object) }
   let(:m) {double}
 
-  context "#help" do
+  context ".commands" do
     it "responds to .help with information about itself." do
-      plugin.class.help.matchers.should eql(".nextmeetup")
-      plugin.class.help.description.should eql('Get the next meetup information.')
+      plugin.class.commands.matchers.should eql(".nextmeetup")
+      plugin.class.commands.description.should eql('Get the next meetup information.')
     end
   end
 

--- a/spec/plugin/reddit_joke_spec.rb
+++ b/spec/plugin/reddit_joke_spec.rb
@@ -23,10 +23,10 @@ describe TurbotPlugins::RedditJoke do
     end
   end
 
-  context "#help" do
+  context ".commands" do
     it "should print the plugins help message." do
-      plugin.class.help.matchers.should eql("'.joke me', '.joke'")
-      plugin.class.help.description.should eql("Random joke from reddit.com/r/jokes.")
+      plugin.class.commands.matchers.should eql("'.joke me', '.joke'")
+      plugin.class.commands.description.should eql("Random joke from reddit.com/r/jokes.")
     end
   end
 end

--- a/spec/plugin/turbotinfo_spec.rb
+++ b/spec/plugin/turbotinfo_spec.rb
@@ -6,10 +6,10 @@ describe TurbotPlugins::TurbotInfo do
   subject(:plugin) {TurbotPlugins::TurbotInfo.new(double.as_null_object) }
   let(:m) { double }
 
-  context "#help" do
+  context "#commands" do
     it "should return the help text for itself." do
-      plugin.class.help.matchers.should eql(".turbotinfo")
-      plugin.class.help.description.should eql("Information about turbot.")
+      plugin.class.commands.matchers.should eql(".turbotinfo")
+      plugin.class.commands.description.should eql("Information about turbot.")
     end
   end
 


### PR DESCRIPTION
commands is more descriptive of what we are doing, and
.help is also matched by cinch itself so we were getting
odd "#PluginCommand:0x9cd897c" output from cinch's
internal help handler.
