### PR TITLE
#30 - change travis-ci notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,6 @@ notifications:
     channels:
       - "irc.freenode.org#turbot"
       - "irc.freenode.org#tamparb"
-  skip_join: true
+    on_success: change
+    on_failure: change
+    skip_join: true


### PR DESCRIPTION
Change the Travis-CI IRC notifications to only send
messages to the IRC channels when there are changes
to the build status.

[#30](https://github.com/rondale-sc/turbot/issues/30)
